### PR TITLE
Remove ShortPatchList error for patching

### DIFF
--- a/src/patch.rs
+++ b/src/patch.rs
@@ -52,9 +52,9 @@ pub fn apply_patch_list(patch: &ParamList, source: &mut ParamList) -> Result<()>
     let ParamList(patch) = patch;
     let ParamList(source) = source;
 
-    if patch.len() < source.len() {
+    /*if patch.len() < source.len() {
         return Err(Error::ShortPatchList);
-    }
+    }*/
 
     for (idx, param) in patch.iter().enumerate() {
         if *param == ParamKind::Hash(hash40("dummy")) {


### PR DESCRIPTION
I removed the exception for when the patch file is shorter than the source file. I found a hard time explaining in words as to why to do this so I created this visual. It gives better support for added entries and makes patching order commutative. This change is meant for both parcel and ARCropolis.

![image](https://github.com/blu-dev/prcx/assets/6856627/7b520695-a324-4cf6-901f-6287bcdf555c)

I thought about all the potential issues that this change could cause and most of them come down to malformed PRCX's where currently, ARCropolis would ignore the PRCX while without the exception check, the game will likely crash.

![image](https://github.com/blu-dev/prcx/assets/6856627/5a1de94e-37d7-427e-874c-41ac1bc66a88)
